### PR TITLE
Fix `WAVETABLE_SIZE`

### DIFF
--- a/wavetable.cpp
+++ b/wavetable.cpp
@@ -84,7 +84,7 @@ const char* ParseWAV(Sample* s, const char* fname) {
 	return "error";
 }
 
-#define WAVETABLE_SIZE (1024+9) // 9 octaves, top octave is 512 samples
+#define WAVETABLE_SIZE (1022+9) // 9 octaves, top octave is 512 samples
 
 enum EWavetables {
 	WT_SAW,
@@ -326,5 +326,3 @@ int main(int argc, char **argv)
 	}
     return 0;
 }
-
-


### PR DESCRIPTION
`WAVETABLE_SIZE` is currently set to 1033 (1024+9). However, it should rather be 1031 (1022+9), since 512+256+128+64+32+16+8+4+2=1022. 

This matches the actual number of elements for each wave in `wavetable.h`, e.g. [the first wave](https://github.com/plinkysynth/wavetable/blob/main/wavetable.h#L4-L12) actually contains 1031 not 1033 elements. 